### PR TITLE
auto cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ inputs:
     default: false
   buildtmbuild:
       description: 'Will build tmbuild itself'
-      default: true
+      default: false
   # config optional:
   libjsonpath:
       description: 'path to libs.json'

--- a/index.js
+++ b/index.js
@@ -5,12 +5,14 @@ const exec = require('@actions/exec');
 const tc = require('@actions/tool-cache');
 
 
+
 // internal dependencies
 const utils = require("./internal/utils");
 const tools = require("./internal/tools");
 const build = require("./internal/build");
 const cache = require("./internal/cache");
 const os = require("os");
+const fs = require('fs');
 
 global.log_out_content = "";
 
@@ -23,19 +25,25 @@ async function build_tmbuild(buildconfig, ending) {
 }
 
 (async () => {
+    let caches = [];
+    let new_caches = [];
     try {
         const canBuild = utils.getInput("build") === 'true';
-        const buildtmbuild = utils.getInput("buildtmbuild") === 'true';
+        let buildtmbuild = utils.getInput("buildtmbuild") === 'true';
         const libpath = utils.getInput("libpath");
         const buildconfig = utils.getInput("buildconfig");
+        const libjson = utils.parseLibsFile(utils.getInput("libjsonpath"));
         // cache settings:
         const cacheLibs = utils.getInput("cacheLibs") === 'true';
         const useCache = utils.getInput("useCache") === 'true';
-        const cacheVersion = utils.getInput("cacheVersion");
+        const cacheVersion = await tools.hash("./utils/tmbuild/tmbuild.c");
+        const libcacheVersion = await tools.hash(`${utils.getInput("libjsonpath")}/libs.json`);
+        const unittestcacheVersion = await tools.hash(`./unit_test/unit_test.c`) + "_" + await tools.hash(`./unit_test/unit_test_renderer.c`);
         const ending = (os.platform() == "win32") ? ".exe" : "";
         // if true package and cache at the end libs and tmbuild      
         let libCacheIsDirty = false;
         let tmbuildCacheIsDirty = false;
+        let unittestCacheIsDirty = true;
         // artifact
         const packageArtifact = utils.getInput("packageArtifact") === 'true';
         // downloads the cache and if cache does not exist it will install it:
@@ -44,14 +52,14 @@ async function build_tmbuild(buildconfig, ending) {
             if (cacheLibs) {
                 try {
                     core.startGroup("[tmbuild-action] get cached dependencies");
-                    await cache.get("libs", cacheVersion);
+                    await cache.get("libs", libcacheVersion);
+                    caches.push({ name: "libs", version: libcacheVersion });
                     core.endGroup();
                 } catch (e) {
                     utils.info(e.message);
                     await tools.install("bearssl");
                     await tools.install("premake5");
                     if (os.platform() != "win32") {
-                        const libjson = utils.parseLibsFile(utils.getInput("libjsonpath"));
                         const toolObject = utils.getLib(libjson, "premake5");
                         const toolname = toolObject.lib;
                         await tools.chmod(`${libpath}/${toolname}/premake5`);
@@ -61,41 +69,87 @@ async function build_tmbuild(buildconfig, ending) {
             }
             // downloads cached tmbuild version
             if (!buildtmbuild) {
+                core.startGroup(`[tmbuild-action] get cached tmbuild-${buildconfig}`);
                 try {
-                    core.startGroup(`[tmbuild-action] get cached tmbuild-${buildconfig}`);
                     await cache.get(`tmbuild`, cacheVersion);
-                    core.endGroup();
+                    caches.push({ name: "tmbuild", version: cacheVersion });
                 } catch (e) {
                     utils.info(e.message);
                     await build_tmbuild(buildconfig, ending);
                     tmbuildCacheIsDirty = true;
                 }
+                core.endGroup();
             }
+
+            core.startGroup(`[tmbuild-action] get cached unit-test-${buildconfig}`);
+            try {
+                await cache.get(`unit-test`, unittestcacheVersion);
+                caches.push({ name: "unit-test", version: unittestcacheVersion });
+                await utils.cp(`./bin/unit_test/${buildconfig}/unit-test${ending}`, `./bin`);
+                unittestCacheIsDirty = false;
+            } catch (e) {
+                utils.info("Cannot get unit test from cache");
+            }
+            core.endGroup();
+
         } else {
             await tools.install("bearssl");
             await tools.install("premake5");
             if (os.platform() != "win32") {
-                const libjson = utils.parseLibsFile(utils.getInput("libjsonpath"));
                 const toolObject = utils.getLib(libjson, "premake5");
                 const toolname = toolObject.lib;
                 await tools.chmod(`${libpath}/${toolname}/premake5`);
             }
         }
 
+        // cache tmbuild if needed
         if (useCache && tmbuildCacheIsDirty) {
-            await cache.set(`./bin/tmbuild/${buildconfig}`, `tmbuild`, cacheVersion);
+            try {
+                await cache.set(`./bin/tmbuild/${buildconfig}`, `tmbuild`, cacheVersion);
+                new_caches.push({ name: "tmbuild", version: cacheVersion });
+            } catch (e) {
+                utils.warning(`There was an error with setting the cache for tmbuild ${e.message}`);
+                // make sure we recover from error and build tmbuild again....
+                buildtmbuild = true;
+                tmbuildCacheIsDirty = false;
+            }
         }
 
+        // build tmuild if needed
         if (buildtmbuild && !tmbuildCacheIsDirty) {
             await build_tmbuild(buildconfig, ending);
         }
 
+        // build engine or project
         if (canBuild) {
             await build.tmbuild(utils.getInput("package"));
+            if (useCache && unittestCacheIsDirty) {
+                try {
+                    await utils.cp(`./bin/${buildconfig}/unit-test${ending}`, `./bin/unit_test/${buildconfig}`);
+                    try {
+                        const toolPath = utils.getLibPath(libjson, "unit-test");
+                        if (fs.existsSync(toolPath)) {
+                            await cache.set(toolPath, `unit-test`, unittestcacheVersion);
+                            new_caches.push({ name: "unit-test", version: unittestcacheVersion });
+                        } else {
+                            utils.info(`There was an error with setting the cache for unit-test, ${toolPath} could not be found`);
+                        }
+                    } catch (e) {
+                        utils.info(`There was an error with setting the cache for unit-test: ${e.message}`);
+                    }
+                } catch (e) {
+                    utils.info(`There was an error with setting the cache for unit-test, ./bin/${buildconfig}/uint-test${ending} could not be found.\nPossible reason the build failed.`);
+                }
+            }
         }
 
         if (useCache && libCacheIsDirty) {
-            await cache.set(libpath, `libs`, cacheVersion);
+            try {
+                await cache.set(libpath, `libs`, libcacheVersion);
+                new_caches.push({ name: "libs", version: libcacheVersion });
+            } catch (e) {
+                utils.warning(`There was an error with setting the cache for libs ${e.message}`);
+            }
         }
 
         const currentDate = new Date();
@@ -129,7 +183,7 @@ async function build_tmbuild(buildconfig, ending) {
         const subst = ``;
         const result = JSON.stringify(global.log_out_content).replace(regex, subst).replace(/\\n/g, "\\n");
         core.setOutput(`result`, result);
-        
+
         const currentDate = new Date();
         const date = currentDate.getDate();
         const month = currentDate.getMonth();
@@ -143,4 +197,11 @@ async function build_tmbuild(buildconfig, ending) {
             core.endGroup();
         }
     }
+
+    core.startGroup(`[tmbuild-action] caches`);
+    core.info("Caches:");
+    caches.forEach(element => core.info(`name: ${element.name}  version: ${element.version}`));
+    core.info("New Caches:");
+    new_caches.forEach(element => core.info(`name: ${element.name}  version: ${element.version}`));
+    core.endGroup();
 })();

--- a/internal/tools.js
+++ b/internal/tools.js
@@ -102,6 +102,31 @@ async function exec(tool, args) {
 exports.exec = exec;
 
 
+async function hash(file) {
+    let myOutput = '';
+    let myError = '';
+    const options = {};
+    options.listeners = {
+        stdout: (data) => {
+            myOutput += data.toString();
+        },
+        stderr: (data) => {
+            myError += data.toString();
+        }
+    };
+    options.silent = !core.isDebug();
+    try {
+        if (!fs.existsSync(file)) throw new Error(`Error: Could not find ${file}`);
+        await e.exec(`git hash-object ${file}`, [], options);
+        return myOutput;
+    } catch (e) {
+        utils.info(`There was an error with git hash-object ${file}`);
+        throw new Error(e.message);
+    }
+}
+exports.hash = hash;
+
+
 async function storeFolder(artifactName, path) {
 
     let files = [];

--- a/internal/utils.js
+++ b/internal/utils.js
@@ -198,13 +198,16 @@ function getLib(libjson, lib) {
 
 
 function getLibPath(libjson, lib) {
-    if (lib != "tmbuild") {
+    if (lib != "tmbuild" && lib != "unit-test") {
         const libobject = getLib(libjson, lib);
         const libfolder = getInput("libpath");
         return `${libfolder}/${libobject.lib}`;
-    } else {
+    } else if (lib == "tmbuild") {
         const buildconfig = getInput("buildconfig");
         return `./bin/tmbuild/${buildconfig}`;
+    } else {
+        const buildconfig = getInput("buildconfig");
+        return `./bin/unit_test/${buildconfig}`;
     }
 }
 


### PR DESCRIPTION
- added hash of tmbuild as id for cache
- added auto hash of objects and added unit-test as a cached version
- improved cache finding of unit-test
- changed not found behavior of cache
- on demand logging test
- corrected spelling-mistake and cache logging
- uses tmbuild cache
- added missing fs support
- corrected check if unit test is there
- unit-test -> unit_test folder name
- auto cache unit test if cache cannot be found